### PR TITLE
Update the parcel selection to available action page to use new endpoint

### DIFF
--- a/server/routes/actions.js
+++ b/server/routes/actions.js
@@ -9,7 +9,7 @@ module.exports = [
     path: '/actions',
     handler: async (request, h) => {
       const parcelRef = getParcelRef(request)
-      const actions = await actionsService.getActions()
+      const actions = await actionsService.getActions(parcelRef)
       const model = actionsModel(actions, parcelRef)
       return h.view('actions', { model })
     }

--- a/server/services/actions-service.js
+++ b/server/services/actions-service.js
@@ -3,8 +3,8 @@ const wreck = require('@hapi/wreck').defaults({
   timeout: config.restClientTimeoutMillis
 })
 
-async function getActions () {
-  const response = await wreck.get(`${config.paymentUrl}/actions`, { json: true })
+async function getActions (parcelRef) {
+  const response = await wreck.get(`${config.paymentUrl}/parcels/${parcelRef}/actions`, { json: true })
   console.log('actions retrieved', response.payload)
   const actions = response.payload && response.payload.actions
   return actions || []

--- a/test/services/actions-service.test.js
+++ b/test/services/actions-service.test.js
@@ -2,12 +2,13 @@ let actionsService
 jest.mock('@hapi/wreck')
 
 let payload
+const parcelRef = 'AB12345678'
 
 function stubWreckCall () {
   const wreck = require('@hapi/wreck')
   wreck.defaults = () => {
     return {
-      get: () => {
+      get: (ref) => {
         return Promise.resolve({ payload })
       }
     }
@@ -30,7 +31,7 @@ describe('actionService', () => {
   test('get actions return JSON', async () => {
     const mockActions = { actions: [{ id: '1', description: 'an action' }] }
     payload = mockActions
-    const result = await actionsService.getActions()
+    const result = await actionsService.getActions(parcelRef)
     expect(result).toBeDefined()
     expect(result.length).toEqual(1)
     expect(result[0]).toEqual(mockActions.actions[0])
@@ -38,7 +39,7 @@ describe('actionService', () => {
 
   test('get actions returns empty array for empty payload', async () => {
     payload = undefined
-    const result = await actionsService.getActions()
+    const result = await actionsService.getActions(parcelRef)
     expect(result).toBeDefined()
     expect(result.length).toEqual(0)
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FCEP-60

The endpoint that returns the list of available actions has moved from /actions to /parcels/{parcelRef}/actions